### PR TITLE
Fix HTTP 404 error when loading SteamDB logo

### DIFF
--- a/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
+++ b/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
@@ -64,6 +64,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 						<a
 							href={`https://www.steamgifts.com/giveaways/search?q=${name}`}
 							target="_blank"
+							rel="noreferrer"
 							title="Search for active giveaways"
 						>
 							<i className="fa">
@@ -73,6 +74,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 						<a
 							href={`http://store.steampowered.com/search/?term=${name}`}
 							target="_blank"
+							rel="noreferrer"
 							title="Search on Steam"
 						>
 							<i className="fa fa-steam"></i>
@@ -80,6 +82,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 						<a
 							href={`https://steamdb.info/search/?a=app&q=${name}`}
 							target="_blank"
+							rel="noreferrer"
 							title="Search on SteamDB"
 						>
 							<i className="fa">
@@ -89,6 +92,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 						<a
 							href={`https://barter.vg/search?q=${name}`}
 							target="_blank"
+							rel="noreferrer"
 							title="Search on Barter.vg"
 						>
 							<i className="fa">

--- a/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
+++ b/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
@@ -11,8 +11,8 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 			description: () => (
 				<ul>
 					<li>
-						If you cannot access a giveaway because of many different reasons, a "Search Links" row
-						is added to the table of the{' '}
+						If you cannot access a giveaway because of many different reasons, a &quot;Search
+						Links&quot; row is added to the table of the{' '}
 						<a href="https://www.steamgifts.com/giveaway/FN2PK/">error</a> page containing 4 links
 						that allow you to search for the game elsewhere:
 					</li>

--- a/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
+++ b/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
@@ -8,6 +8,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 		super();
 		this.info = {
 			// by Revadike
+			// eslint-disable-next-line react/display-name
 			description: () => (
 				<ul>
 					<li>

--- a/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
+++ b/src/modules/Giveaways/GiveawayErrorSearchLinks.jsx
@@ -26,7 +26,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 						</li>
 						<li>
 							<i className="fa">
-								<img src="https://steamdb.info/static/logos/favicon-16x16.png"></img>
+								<img src="https://steamdb.info/static/logos/16px.png"></img>
 							</i>{' '}
 							allows you to search for the game on SteamDB.
 						</li>
@@ -83,7 +83,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 							title="Search on SteamDB"
 						>
 							<i className="fa">
-								<img src="https://steamdb.info/static/logos/favicon-16x16.png" />
+								<img src="https://steamdb.info/static/logos/16px.png" />
 							</i>
 						</a>
 						<a

--- a/src/modules/Giveaways/GiveawayErrorSearchLinks.tsx
+++ b/src/modules/Giveaways/GiveawayErrorSearchLinks.tsx
@@ -47,10 +47,10 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 		};
 	}
 
-	init() {
+	init = () => {
 		const table = document.getElementsByClassName('table--summary')[0];
 		if (!this.esgst.giveawayPath || !table) return;
-		let name = encodeURIComponent(
+		const name = encodeURIComponent(
 			table.getElementsByClassName('table__column__secondary-link')[0].textContent
 		);
 		DOM.insert(
@@ -104,7 +104,7 @@ class GiveawaysGiveawayErrorSearchLinks extends Module {
 				</div>
 			</div>
 		);
-	}
+	};
 }
 
 const giveawaysGiveawayErrorSearchLinks = new GiveawaysGiveawayErrorSearchLinks();


### PR DESCRIPTION
In setting 3.19 Giveaway Error Search Links, the logo of SteamDB does not load due to HTTP 404 error.
![ảnh](https://github.com/rafaelgomesxyz/esgst/assets/2577653/b21ed05f-4d24-49f4-9e60-927016afc19f)

In this PR, I would like to add the following changes:
- Fix HTTP 404 error when loading SteamDB logo
- Some code refactors to remedy eslint error
- Migrate the code to TypeScript.