### PR TITLE
Comment Tracker: Fix edited comment appears as read instead of unread

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"editor.rulers": [100]
+}

--- a/src/modules/Comments.js
+++ b/src/modules/Comments.js
@@ -160,9 +160,11 @@ class Comments extends Module {
 		comment.id = comment.permalink
 			? comment.permalink.getAttribute('href').match(/\/comment\/(.+)/)[1]
 			: '';
-		comment.timestamp = parseInt(
-			comment.actions.querySelector(`[data-timestamp]`).getAttribute('data-timestamp')
-		);
+		matches = comment.actions.querySelectorAll('[data-timestamp]');
+		n = matches.length;
+		if (n > 0) {
+			comment.timestamp = parseInt(matches[n - 1].getAttribute('data-timestamp'));
+		}
 		if (!main || Shared.common.isCurrentPath('Messages')) {
 			if (this.esgst.sg) {
 				try {


### PR DESCRIPTION
Steps to reproduce:
- Enable ESGST setting "5.7.6 - Fade out read comments"
- Visit this comment:
`https://www.steamgifts.com/go/comment/vYbrsc9`
- Click the button "Mark all comments in this page as read"
- Wait for the comment to be edited
- Reload the page, edited comments appear as read.

Actual results:
- Open Firefox's add-on debugging tool at:
`about:debugging#/runtime/this-firefox`
- Inspect ESGST
- In debugging console tab, execute this line:
`browser.storage.local.get('discussions').then((item) => {console.log(JSON.parse(item.discussions)['tnWVh'].readComments['vYbrsc9'])})`
- The value `1688003432` is returned
- Inspect the comment on SG web site, we could see that the created timestamp is `1688003432` and the edited timestamp is `1688154585`.

Expected results:
- Edited comments show up as unread
- ESGST should keep track of edited time, then created time, in order of preference.

---

In this PR, I would like to add the following changes:
- Fix edited comment appears as read instead of unread
- Migrate the code to TypeScript.
